### PR TITLE
Removed duplicate cas: key that had an included path attribute. 

### DIFF
--- a/etc/lab-metric/018NY6XC00LM1FYB8674M2X435.yaml
+++ b/etc/lab-metric/018NY6XC00LM1FYB8674M2X435.yaml
@@ -5,8 +5,6 @@ uom: ppm
 name: Diazinon
 type: Pesticide
 stub: diazinon
-cas:
-  path: cas://987-fdFDSF
 biotrack:
   name: ~
   path: ~


### PR DESCRIPTION
I chose this one as removing it aligned the yaml with other lab metric files.

Signed-off-by: Bobby Hines <bobbyahines@gmail.com>