### PR TITLE
Additional terpenes for lab-metrics.

### DIFF
--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32N.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32N.yaml
@@ -1,0 +1,5 @@
+id: 01FQFG9EJB2ZNCCGA3W92QF32N
+cas: "3691-11-0"
+name: "Alpha-bulnesene"
+type: Terpene
+stub: alpha_bulnesene

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32R.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32R.yaml
@@ -1,0 +1,5 @@
+id: 01FQFG9EJB2ZNCCGA3W92QF32R
+cas: "489-28-1"
+name: "Alpha-maaliene"
+type: Terpene
+stub: alpha_maaliene

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32V.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32V.yaml
@@ -1,0 +1,5 @@
+id: 01FQFG9EJB2ZNCCGA3W92QF32V
+cas: "489-29-2"
+name: "Beta-maaliene"
+type: Terpene
+stub: beta_maaliene

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32W.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32W.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF32W
+cas: "99-86-5"
+name: "Alpha-terpinene"
+type: Terpene
+stub: alpha_terpinene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32X.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32X.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF32X
+cas: "55-10-2"
+name: "Beta-phellandrene"
+type: Terpene
+stub: beta_phellandrene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32Y.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF32Y.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF32Y
+cas: "13877-91-3"
+name: "Beta-ocimene"
+type: Terpene
+stub: beta_ocimene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF334.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF334.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF334
+cas: "87-44-5"
+name: Caryophyllene
+type: Terpene
+stub: caryophyllene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF33G.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF33G.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF33G
+cas: "512-61-8"
+name: "Alpha-santalene"
+type: Terpene
+stub: alpha_santalene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF33X.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF33X.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF33X
+cas: "106-22-9"
+name: Citronellol
+type: Terpene
+stub: citronellol
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF33Z.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF33Z.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF33Z
+cas: "473-15-4"
+name: Eudesmol
+type: Terpene
+stub: eudesmol
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF341.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF341.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF341
+cas: "3691-12-1"
+name: "Gamma-guaiene"
+type: Terpene
+stub: gamma_guaiene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF343.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF343.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF343
+cas: "1195-79-5"
+name: Fenchone
+type: Terpene
+stub: fenchone
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF347.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF347.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF347
+cas: "1461-03-06"
+name: Himachalene
+type: Terpene
+stub: himachalene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF34E.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF34E.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF34E
+cas: "18252-46-5"
+name: "Cis-alpha-bergamotene"
+type: Terpene
+stub: cis_alpha_bergamotene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF34W.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF34W.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF34W
+cas: "1197-06-4"
+name: "Cis-carveol"
+type: Terpene
+stub: cis_carveol
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF35C.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF35C.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF35C
+cas: "28290-20-2"
+name: Selinadiene
+type: Terpene
+stub: selinadiene
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF35D.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF35D.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF35D
+cas: "110-93-0"
+name: Sulcatone
+type: Terpene
+stub: sulcatone
+...

--- a/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF35E.yaml
+++ b/etc/lab-metric/01FQFG9EJB2ZNCCGA3W92QF35E.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJB2ZNCCGA3W92QF35E
+cas: "3387-41-5"
+name: Thujene
+type: Terpene
+stub: thujene
+...

--- a/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEV4.yaml
+++ b/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEV4.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJC2Z0EFM33WDMPDEV4
+cas: "3779-61-1"
+name: "Trans-ocimene"
+type: Terpene
+stub: trans_ocimene
+...

--- a/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVF.yaml
+++ b/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVF.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJC2Z0EFM33WDMPDEVF
+cas: "58893-88-2"
+name: "Pseudo-valencene"
+type: Terpene
+stub: pseudo_valencene
+...

--- a/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVG.yaml
+++ b/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVG.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJC2Z0EFM33WDMPDEVG
+cas: "89-83-8"
+name: Thymol
+type: Terpene
+stub: thymol
+...

--- a/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVJ.yaml
+++ b/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVJ.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJC2Z0EFM33WDMPDEVJ
+cas: "4948-29-2"
+name: "Trans-2-pinanol"
+type: Terpene
+stub: trans_2_pinanol
+...

--- a/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVK.yaml
+++ b/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVK.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJC2Z0EFM33WDMPDEVK
+cas: "13474-59-4"
+name: "Trans-alpha-bergamotene"
+type: Terpene
+stub: trans_alpha_bergamotene
+...

--- a/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVQ.yaml
+++ b/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVQ.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJC2Z0EFM33WDMPDEVQ
+cas: "77-53-2"
+name: Cedrol
+type: Terpene
+stub: cedrol
+...

--- a/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVR.yaml
+++ b/etc/lab-metric/01FQFG9EJC2Z0EFM33WDMPDEVR.yaml
@@ -1,0 +1,7 @@
+---
+id: 01FQFG9EJC2Z0EFM33WDMPDEVR
+cas: "19888-34-7"
+name: "Humulene Oxide II"
+type: Terpene
+stub: humulene_oxide_ii
+...


### PR DESCRIPTION
Following terpenes are added:

alpha-bulnesene, alpha-maaliene, alpha-santalene, alpha-terpinene,
beta-maaliene, beta-ocimene, beta-phellandrene,
caryophyllene, cedrol, cis-alpha-bergamotene, cis-carveol, citronellol,
eudesmol,
fenchone,
gamma-guaiene,
himachalene, humulene oxide ii,
pseudo-valencene,
selinadiene, sulcatone,
thujene, thymol, trans-2-pinanol, trans-alpha-bergamotene, trans-ocimene.

Signed-off-by: Bobby Hines <bobbyahines@gmail.com>